### PR TITLE
fix: Missing async in documentation

### DIFF
--- a/apps/docs/pages/getting-started.mdx
+++ b/apps/docs/pages/getting-started.mdx
@@ -70,7 +70,7 @@ Secondly, we'll need to create a router, a server, and our first route.
 import {createServer} from '@kaito-http/core';
 import {router, getContext} from './context';
 
-const app = router().add('GET', '/', ({ctx}) => {
+const app = router().add('GET', '/', async ({ctx}) => {
 	return {
 		uptime: ctx.uptime,
 		time_now: Date.now(),


### PR DESCRIPTION
The code snippet on the getting started page doesn't work without when supplying a non-async function for the route, so I added the `async` on the docs.