### PR TITLE
add types to package.json

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,6 +10,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
+			"types": "./src/index.ts",
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,10 +10,12 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
+			"types": "./src/index.ts",
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		},
 		"./stream": {
+			"types": "./src/stream/stream.ts",
 			"import": "./dist/stream/stream.js",
 			"require": "./dist/stream/stream.cjs"
 		}

--- a/packages/llhttp-wasm/package.json
+++ b/packages/llhttp-wasm/package.json
@@ -10,6 +10,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
+			"types": "./src/index.ts",
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		}

--- a/packages/uws/package.json
+++ b/packages/uws/package.json
@@ -9,6 +9,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
+			"types": "./src/index.ts",
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		}


### PR DESCRIPTION
Adds types exports to improve Devex

Types are described here:
https://nodejs.org/api/packages.html#community-conditions-definitions

Currently main is not actually passing `tsc -build` but it's hidden in cursor/vscode because `dist` types are not in sync. This happens to make that failing build more obvious.

With this
 - navigating around in vscode/cursor takes you to the ts files rather than files in dist/ directories.
 - vscode typescript language server uses ts files when resolving sub-package dependencies rather than dist/ - so no need to run yarn build all the time during dev
