### PR TITLE
Fixes+tests for nested routers where the parent or child is "/"

### DIFF
--- a/examples/client/src/basic.ts
+++ b/examples/client/src/basic.ts
@@ -9,7 +9,7 @@ function assertNever(x: never): never {
 	throw new Error(`Unhandled case: ${JSON.stringify(x)}`);
 }
 
-const getResponse = await api.get('/v1/response/', {
+const getResponse = await api.get('/v1/response', {
 	response: true,
 });
 

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -191,6 +191,34 @@ describe('Router', () => {
 				data: {id: '1'},
 			});
 		});
+
+		it('should handle merging on /', () => {
+			const child = router.get('/', {
+				run: () => 'child',
+			});
+
+			const namedChild = router.get('/', () => 'named child').get('/child', () => 'named child');
+
+			const parent = router
+				.post('/', () => 'parent')
+				.delete('/', () => 'parent')
+				.merge('/', child)
+				.merge('/named', namedChild);
+
+			// Copying into Array.from, easier access methods than the SetIterator
+			const routes = Array.from(parent.routes.values());
+
+			// Ensure that the path of the GET merged is simply /
+			const getChildRoute = routes.find(r => r.method === 'GET' && r.path === '/');
+			assert.strictEqual(getChildRoute?.path, '/');
+
+			// Ensure the named child is unaffected, and not missing any slashes
+			const getNamedChildRoute = routes.find(r => r.method === 'GET' && r.path === '/named');
+			assert.strictEqual(getNamedChildRoute?.path, '/named');
+
+			const getNestedNameChildRoute = routes.find(r => r.method === 'GET' && r.path === '/named/child');
+			assert.strictEqual(getNestedNameChildRoute?.path, '/named/child');
+		});
 	});
 
 	describe('404 handling', () => {

--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -12,9 +12,9 @@ import {KaitoHead} from '../head.ts';
 import {KaitoRequest} from '../request.ts';
 import type {AnyQuery, AnyRoute, Route} from '../route.ts';
 import {
-	isNodeLikeDev,
 	type ErroredAPIResponse,
 	type ExtractRouteParams,
+	isNodeLikeDev,
 	type KaitoMethod,
 	type MaybePromise,
 } from '../util.ts';
@@ -29,7 +29,7 @@ type PrefixRoutesPathInner<R extends AnyRoute, Prefix extends `/${string}`> =
 		infer Query,
 		infer BodyOutput
 	>
-		? Route<ContextTo, Result, `${Prefix}${Path}`, AdditionalParams, Method, Query, BodyOutput>
+		? Route<ContextTo, Result, `${Prefix}${Path extends '/' ? '' : Path}`, AdditionalParams, Method, Query, BodyOutput>
 		: never;
 
 type PrefixRoutesPath<Prefix extends `/${string}`, R extends AnyRoute> = R extends R
@@ -144,7 +144,10 @@ export class Router<ContextFrom, ContextTo, RequiredParams extends Record<string
 	> => {
 		const newRoutes = [...other.state.routes].map(route => ({
 			...route,
-			path: `${pathPrefix}${route.path as string}`,
+			// handle pathPrefix = / & route.path = / case causing //
+			// we intentionally are replacing on the joining path and not the pathPrefix, in case of
+			// /named -> merged to -> / causing /named/ not /named
+			path: `${pathPrefix}${route.path === '/' ? '' : route.path}`,
 		}));
 
 		return new Router({

--- a/packages/core/test/params/lab.ts
+++ b/packages/core/test/params/lab.ts
@@ -1,13 +1,23 @@
 import {create} from '../../src/index.ts';
+import {z} from 'zod';
 
 const router = create();
 
-const guildChannelRouter = router.params<{guild_id: string; channel_id: string}>().get('/', ({params}) => ({
-	guild: params.guild_id,
-	channel: params.channel_id,
-}));
+const guildChannelRouter = router
+	.params({
+		guild_id: z.string(),
+		channel_id: z.string(),
+	})
+	.get('/', ({params}) => ({
+		guild: params.guild_id,
+		channel: params.channel_id,
+	}));
 
-const guildRouter = router.params<{guild_id: string}>().merge('/channels/:channel_id', guildChannelRouter);
+const guildRouter = router
+	.params({
+		guild_id: z.string(),
+	})
+	.merge('/channels/:channel_id', guildChannelRouter);
 
 const app = router.merge('/guilds/:guild_id', guildRouter);
 


### PR DESCRIPTION
There are two current issues with merging routers in Kaito.

1) If you merge on `/`, and the child router has a method on `/`, the resultant path is `//`.
2) If you merge on `/named`, and have a child route of `/`, the resultant path is `/named/` (note the explicit trailing `/`).

This fixes both of those issues by, at a type level and a runtime level, checking if the *child* router path is explicitly `/`.
Checking the child, rather than the parent path, solves both cases here, while the parent check doesn't solve the `/named/` case.