### PR TITLE
docs: change `set` to `append` in the cookie reference

### DIFF
--- a/apps/docs/src/pages/recipes/cookies.mdx
+++ b/apps/docs/src/pages/recipes/cookies.mdx
@@ -22,7 +22,7 @@ export const {getContext, router} = createUtilities(async (req, res) => {
 			return header ? parse(header) : {};
 		},
 		setCookie(name: string, value: string, options: SerializeOptions) {
-			res.headers.set('Set-Cookie', serialize(name, value, options));
+			res.headers.append('Set-Cookie', serialize(name, value, options));
 		},
 	};
 });


### PR DESCRIPTION
Ok, so basically if you `set` the `Set-Cookie` header it will **override** any previously set header which is no bueno in logic as users could set multiple cookies for stuff.

This change allows for multiple `Set-Cookie` headers as per [RFC 6265](https://httpwg.org/specs/rfc6265.html#sane-set-cookie:~:text=An%20origin%20server%20can%20include%20multiple%20Set%2DCookie%20header%20fields%20in%20a%20single%20response.%20The%20presence%20of%20a%20Cookie%20or%20a%20Set%2DCookie%20header%20field%20does%20not%20preclude%20HTTP%20caches%20from%20storing%20and%20reusing%20a%20response.)