### PR TITLE
Add `fami` to docs for handling cookies

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,4 @@
+{
+	"formatter": "prettier",
+	"format_on_save": "on",
+}

--- a/apps/docs/src/content/recipes/cookies.mdx
+++ b/apps/docs/src/content/recipes/cookies.mdx
@@ -2,9 +2,79 @@
 
 Kaito does not include cookie handling. You can add it yourself in your context — here's how.
 
-## Example
+## Using fami (recommended)
 
-We recommend the [`cookie`](https://www.npmjs.com/package/cookie) package. It has a tiny footprint and zero dependencies.
+We recommend the [`fami`](https://www.npmjs.com/package/fami) package. It has zero dependencies, a tiny footprint, and first-class Kaito support with full type safety via `fami/kaito`.
+
+```bash
+bun i fami
+```
+
+### With `fami/kaito`
+
+The `fami/kaito` adapter wraps your existing context function and adds `cookies`, `setCookie`, and `deleteCookie` to your context automatically.
+
+```ts
+import {create} from '@kaito-http/core';
+import {createFami} from 'fami/kaito';
+
+const context = createFami([
+	'theme',
+	{
+		name: 'session',
+		httpOnly: true,
+		secure: true,
+		maxAge: 3600,
+	},
+]);
+
+const router = create({
+	getContext: context((req, head) => ({req, head})),
+});
+
+const app = router
+	.get('/cookies', ({ctx}) => {
+		// ctx.cookies is lazily parsed and fully typed
+		return ctx.cookies;
+	})
+	.get('/set-cookie', ({ctx}) => {
+		ctx.setCookie('session', 'abc123');
+		return 'Cookie set';
+	})
+	.get('/delete-cookie', ({ctx}) => {
+		ctx.deleteCookie('session');
+		return 'Cookie deleted';
+	});
+```
+
+### With the low-level API
+
+If you prefer to handle cookies manually, you can use `fami`'s `parse` and `serialize` functions directly.
+
+```ts
+import {create} from '@kaito-http/core';
+import {parse, serialize, type CookieAttributes} from 'fami';
+
+export const router = create({
+	getContext: async (req, head) => {
+		return {
+			req,
+			head,
+			get cookies() {
+				const header = req.headers.get('cookie');
+				return header ? parse(header) : {};
+			},
+			setCookie(name: string, value: string, attributes?: CookieAttributes) {
+				head.headers.append('Set-Cookie', serialize(name, value, attributes));
+			},
+		};
+	},
+});
+```
+
+## Using cookie
+
+The [`cookie`](https://www.npmjs.com/package/cookie) package is another solid option. It has a tiny footprint and zero dependencies.
 
 ```bash
 bun i cookie
@@ -23,7 +93,7 @@ export const router = create({
 				const header = req.headers.get('cookie');
 				return header ? parse(header) : {};
 			},
-			setCookie(name: string, value: string, options: SerializeOptions) {
+			setCookie(name: string, value: string, options?: SerializeOptions) {
 				head.headers.append('Set-Cookie', serialize(name, value, options));
 			},
 		};
@@ -33,4 +103,6 @@ export const router = create({
 
 ## References
 
+- [fami on GitHub](https://github.com/pxseu/fami)
+- [cookie on GitHub](https://github.com/jshttp/cookie)
 - [MDN: Cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie)


### PR DESCRIPTION
Adds documentation for using [fami](https://github.com/pxseu/fami) to handle cookies in Kaito, including both the `fami/kaito` adapter and the low-level API.

Updated to reflect the latest fami kaito implementation from https://github.com/pxseu/fami/pull/1, which:
- Removes the `FamiContextWrapper` type in favor of inferred return types
- Changes `FamiContext` from a type alias to an interface
- Improves cookie lazy-parsing to use `Object.defineProperties` for caching instead of a closure variable
- Simplifies the generic constraints on the `fami()` function

<img width="1200" height="1499" alt="image" src="https://github.com/user-attachments/assets/cfb09004-f7ea-4e82-9b65-cf32d351a32b" />