### PR TITLE
add optional, nullable, nullish, default and coerce to schemas

### DIFF
--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
-import {BaseSchema, k, KArray, KBoolean, KLazy, KNull, KNumber, KRef, KString, KUnion} from './schema.ts';
+import {type BaseSchema, KArray, KBoolean, KLazy, KNull, KNumber, KRef, KString, KUnion, k} from './schema.ts';
 
 describe('Schema', () => {
 	describe('KString', () => {
@@ -564,7 +564,15 @@ describe('Schema', () => {
 			});
 
 			it('should validate property types', () => {
-				assert.throws(() => userSchema.parse({id: '1', name: 'John', email: 'john@example.com'}), /Expected number/);
+				assert.throws(
+					() =>
+						userSchema.parse({
+							id: '1',
+							name: 'John',
+							email: 'john@example.com',
+						}),
+					/Expected number/,
+				);
 				assert.throws(() => userSchema.parse({id: 1, name: 123, email: 'john@example.com'}), /Expected string/);
 				assert.throws(() => userSchema.parse({id: 1, name: 'John', email: 'invalid-email'}), /Invalid email format/);
 			});
@@ -1412,7 +1420,10 @@ describe('Schema', () => {
 		it('should accept objects', () => {
 			assert.deepStrictEqual(schema.parse({}), {});
 			assert.deepStrictEqual(schema.parse({a: 1}), {a: 1});
-			assert.deepStrictEqual(schema.parse({name: 'test', age: 30}), {name: 'test', age: 30});
+			assert.deepStrictEqual(schema.parse({name: 'test', age: 30}), {
+				name: 'test',
+				age: 30,
+			});
 		});
 
 		it('should accept nested structures', () => {
@@ -1492,7 +1503,11 @@ describe('Schema', () => {
 			it('should accept valid record objects', () => {
 				assert.deepStrictEqual(schema.parse({}), {});
 				assert.deepStrictEqual(schema.parse({a: 1}), {a: 1});
-				assert.deepStrictEqual(schema.parse({a: 1, b: 2, c: 3}), {a: 1, b: 2, c: 3});
+				assert.deepStrictEqual(schema.parse({a: 1, b: 2, c: 3}), {
+					a: 1,
+					b: 2,
+					c: 3,
+				});
 			});
 
 			it('should reject non-objects', () => {
@@ -1526,7 +1541,10 @@ describe('Schema', () => {
 			const schema = k.record(k.string().regex(/^[a-z]+$/), k.number());
 
 			it('should validate keys match the pattern', () => {
-				assert.deepStrictEqual(schema.parse({abc: 1, def: 2}), {abc: 1, def: 2});
+				assert.deepStrictEqual(schema.parse({abc: 1, def: 2}), {
+					abc: 1,
+					def: 2,
+				});
 			});
 
 			it("should reject keys that don't match the pattern", () => {
@@ -1778,7 +1796,9 @@ describe('Schema', () => {
 			const schema = k.record(k.literal('constant'), k.number());
 
 			it('should only accept the literal key', () => {
-				assert.deepStrictEqual(schema.parse({constant: 42}), {constant: 42});
+				assert.deepStrictEqual(schema.parse({constant: 42}), {
+					constant: 42,
+				});
 			});
 
 			it('should reject other keys', () => {
@@ -1853,10 +1873,106 @@ describe('Schema', () => {
 				const objectSchema = k.object({a: k.number(), b: k.number()});
 
 				// Record accepts any string keys
-				assert.deepStrictEqual(recordSchema.parse({x: 1, y: 2}), {x: 1, y: 2});
+				assert.deepStrictEqual(recordSchema.parse({x: 1, y: 2}), {
+					x: 1,
+					y: 2,
+				});
 
 				// Object requires specific keys
 				assert.throws(() => objectSchema.parse({x: 1, y: 2}), /Missing required property/);
+			});
+		});
+	});
+
+	describe('modifiers', () => {
+		describe('optional', () => {
+			const schema = k.object({a: k.string(), b: k.string().optional()});
+
+			it('allows the property to be absent', () => {
+				assert.strictEqual(schema.parse({a: 'x'}).b, undefined);
+				assert.deepStrictEqual(schema.parse({a: 'x', b: 'y'}), {
+					a: 'x',
+					b: 'y',
+				});
+			});
+
+			it('still requires non-optional properties', () => {
+				assert.throws(() => schema.parse({b: 'y'}), /Missing required property: a/);
+			});
+
+			it('omits optional properties from the OpenAPI required list', () => {
+				assert.deepStrictEqual((schema.toOpenAPI() as {required: string[]}).required, ['a']);
+			});
+
+			it('drops absent optional properties on serialize', () => {
+				assert.deepStrictEqual(schema.serialize({a: 'x'} as never), {
+					a: 'x',
+				});
+			});
+		});
+
+		describe('nullable / nullish', () => {
+			it('nullable accepts null and the base type', () => {
+				const schema = k.string().nullable();
+				assert.strictEqual(schema.parse(null), null);
+				assert.strictEqual(schema.parse('hello'), 'hello');
+				assert.throws(() => schema.parse(123), /No union option matched|Expected/);
+			});
+
+			it('nullish accepts null and undefined', () => {
+				const schema = k.string().nullish();
+				assert.strictEqual(schema.parse(null), null);
+				assert.strictEqual(schema.parse(undefined), undefined);
+				assert.strictEqual(schema.parse('hello'), 'hello');
+			});
+		});
+
+		describe('default', () => {
+			const schema = k.object({n: k.number().default(42)});
+
+			it('falls back to the default when undefined', () => {
+				assert.deepStrictEqual(schema.parse({}), {n: 42});
+			});
+
+			it('uses the provided value when present', () => {
+				assert.deepStrictEqual(schema.parse({n: 7}), {n: 7});
+			});
+
+			it('exposes the default in OpenAPI and omits it from required', () => {
+				const openapi = schema.toOpenAPI() as {
+					properties: {n: {default: number}};
+					required: string[];
+				};
+				assert.strictEqual(openapi.properties.n.default, 42);
+				assert.deepStrictEqual(openapi.required, []);
+			});
+		});
+
+		describe('coerce.number', () => {
+			it('coerces numeric strings to numbers', () => {
+				assert.strictEqual(k.coerce.number().parse('123'), 123);
+				assert.strictEqual(k.coerce.number().parse(5), 5);
+			});
+
+			it('rejects non-numeric and empty strings', () => {
+				assert.throws(() => k.coerce.number().parse('abc'), /Expected number/);
+				assert.throws(() => k.coerce.number().parse(''), /Expected number/);
+			});
+
+			it('still applies number checks after coercion', () => {
+				assert.throws(() => k.coerce.number().min(10).parse('5'), /greater than or equal to 10/);
+			});
+		});
+
+		describe('with objectFromURLSearchParams', () => {
+			const schema = k.objectFromURLSearchParams({
+				page: k.coerce.number().default(1),
+				q: k.string().optional(),
+			});
+
+			it('applies defaults and optionals to missing params', () => {
+				assert.strictEqual(schema.parse(new URLSearchParams('')).page, 1);
+				assert.deepStrictEqual(schema.parse(new URLSearchParams('page=3&q=hi')), {page: 3, q: 'hi'});
 			});
 		});
 	});

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -142,6 +142,36 @@ export abstract class BaseSchema<Input extends JSONValue, Output, Def extends Ba
 		return k.union([this, other]);
 	}
 
+	/**
+	 * Makes the schema accept `undefined`. Mainly useful for object properties,
+	 * where an optional property is also excluded from the `required` list.
+	 */
+	public optional(): KOptional<Input, Output> {
+		return new KOptional(this);
+	}
+
+	/**
+	 * Makes the schema also accept `null` (equivalent to `.or(k.null())`).
+	 */
+	public nullable(): KUnion<Input | null, Output | null> {
+		return this.or(k.null());
+	}
+
+	/**
+	 * Makes the schema accept both `null` and `undefined`.
+	 */
+	public nullish(): KOptional<Input | null, Output | null> {
+		return this.nullable().optional();
+	}
+
+	/**
+	 * Falls back to `defaultValue` when the value is `undefined`. As with
+	 * {@link optional}, the property is excluded from the `required` list.
+	 */
+	public default(defaultValue: Output): KDefault<Input, Output> {
+		return new KDefault(this, defaultValue);
+	}
+
 	example(example: Input): this;
 	example(): Input | undefined;
 	example(example?: Input) {
@@ -166,6 +196,106 @@ export abstract class BaseSchema<Input extends JSONValue, Output, Def extends Ba
 	 * Traverse immediate children schemas.
 	 */
 	abstract visit(visitor: (schema: BaseSchema<any, any, any>) => void): void;
+}
+
+/////////////////////////////////////////////////////
+///////////////////// KOPTIONAL /////////////////////
+/////////////////////////////////////////////////////
+
+export class KOptional<Input extends JSONValue, Output> extends BaseSchema<
+	Input,
+	Output | undefined,
+	BaseSchemaDef<Input>
+> {
+	public constructor(private readonly schema: BaseSchema<Input, Output, BaseSchemaDef<Input>>) {
+		super({});
+	}
+
+	public override serialize(value: Output | undefined): Input {
+		if (value === undefined) {
+			return undefined as unknown as Input;
+		}
+
+		return this.schema.serialize(value);
+	}
+
+	public override toOpenAPI(): SchemaObject | ReferenceObject {
+		return this.schema.toOpenAPI();
+	}
+
+	public override parseSafe(json: unknown): ParseResult<Output | undefined> {
+		if (json === undefined) {
+			return {success: true, result: undefined};
+		}
+
+		return this.schema.parseSafe(json);
+	}
+
+	public override parse(json: unknown): Output | undefined {
+		const result = this.parseSafe(json);
+
+		if (!result.success) {
+			throw new SchemaError(result.issues);
+		}
+
+		return result.result;
+	}
+
+	public override visit(visitor: (schema: BaseSchema<any, any, any>) => void): void {
+		visitor(this.schema);
+		this.schema.visit(visitor);
+	}
+}
+
+/////////////////////////////////////////////////////
+////////////////////// KDEFAULT /////////////////////
+/////////////////////////////////////////////////////
+
+export class KDefault<Input extends JSONValue, Output> extends BaseSchema<
+	Input,
+	Exclude<Output, undefined>,
+	BaseSchemaDef<Input>
+> {
+	public constructor(
+		private readonly schema: BaseSchema<Input, Output, BaseSchemaDef<Input>>,
+		private readonly defaultValue: Output,
+	) {
+		super({});
+	}
+
+	public override serialize(value: Exclude<Output, undefined>): Input {
+		return this.schema.serialize((value === undefined ? this.defaultValue : value) as Output);
+	}
+
+	public override toOpenAPI(): SchemaObject | ReferenceObject {
+		return {
+			...this.schema.toOpenAPI(),
+			default: this.schema.serialize(this.defaultValue),
+		} as SchemaObject;
+	}
+
+	public override parseSafe(json: unknown): ParseResult<Exclude<Output, undefined>> {
+		if (json === undefined) {
+			return {success: true, result: this.defaultValue as Exclude<Output, undefined>};
+		}
+
+		return this.schema.parseSafe(json) as ParseResult<Exclude<Output, undefined>>;
+	}
+
+	public override parse(json: unknown): Exclude<Output, undefined> {
+		const result = this.parseSafe(json);
+
+		if (!result.success) {
+			throw new SchemaError(result.issues);
+		}
+
+		return result.result;
+	}
+
+	public override visit(visitor: (schema: BaseSchema<any, any, any>) => void): void {
+		visitor(this.schema);
+		this.schema.visit(visitor);
+	}
 }
 
 type Check<T extends string, P extends {} = {}> = {type: T; message?: string | undefined} & Omit<P, 'message'>;
@@ -597,6 +727,36 @@ export class KNumber extends BaseSchema<number, number, NumberDef> {
 }
 
 /////////////////////////////////////////////////////
+/////////////////// KCOERCEDNUMBER //////////////////
+/////////////////////////////////////////////////////
+
+/**
+ * A {@link KNumber} that coerces numeric strings (e.g. from query params or
+ * form data) into numbers before applying the usual number validation.
+ */
+export class KCoercedNumber extends KNumber {
+	public static override create = () => new KCoercedNumber({});
+
+	public override parseSafe(json: unknown): ParseResult<number> {
+		if (typeof json === 'string') {
+			if (json.trim() === '') {
+				return {success: false, issues: new Set([{message: 'Expected number', path: []}])};
+			}
+
+			const coerced = Number(json);
+
+			if (!Number.isFinite(coerced)) {
+				return {success: false, issues: new Set([{message: 'Expected number', path: []}])};
+			}
+
+			return super.parseSafe(coerced);
+		}
+
+		return super.parseSafe(json);
+	}
+}
+
+/////////////////////////////////////////////////////
 ////////////////////// KBOOLEAN //////////////////////
 /////////////////////////////////////////////////////
 
@@ -818,6 +978,10 @@ export class KObject<
 				const fieldValue = value[key];
 
 				if (fieldValue === undefined) {
+					if (this.def.shape[key] instanceof KOptional) {
+						continue;
+					}
+
 					throw new Error(`Missing required property: ${key}`);
 				}
 
@@ -843,7 +1007,9 @@ export class KObject<
 					return [key, value.toOpenAPI()];
 				}),
 			),
-			required: Object.keys(this.def.shape),
+			required: Object.entries(this.def.shape)
+				.filter(([, value]) => !(value instanceof KOptional) && !(value instanceof KDefault))
+				.map(([key]) => key),
 		};
 	}
 
@@ -858,11 +1024,13 @@ export class KObject<
 			for (const key in this.def.shape) {
 				if (Object.prototype.hasOwnProperty.call(this.def.shape, key)) {
 					const value = (json as {[key: string]: unknown})[key];
-					if (value === undefined) {
+					const fieldSchema = this.def.shape[key]!;
+
+					if (value === undefined && !(fieldSchema instanceof KOptional) && !(fieldSchema instanceof KDefault)) {
 						return ctx.addIssue(`Missing required property: ${key}`, [key]);
 					}
 
-					const parseResult = this.def.shape[key]!.parseSafe(value);
+					const parseResult = fieldSchema.parseSafe(value);
 
 					if (!parseResult.success) {
 						return ctx.addIssues(parseResult.issues, [key]);
@@ -933,13 +1101,14 @@ export class KObjectFromURLSearchParams<
 
 			for (const key in this.def.shape) {
 				if (Object.prototype.hasOwnProperty.call(this.def.shape, key)) {
-					const value = json.get(key);
+					const value = json.get(key) ?? undefined;
+					const fieldSchema = this.def.shape[key]!;
 
-					if (value === null) {
+					if (value === undefined && !(fieldSchema instanceof KOptional) && !(fieldSchema instanceof KDefault)) {
 						return ctx.addIssue(`Missing required property: ${key}`, [key]);
 					}
 
-					const parseResult = this.def.shape[key]!.parseSafe(value);
+					const parseResult = fieldSchema.parseSafe(value);
 
 					if (!parseResult.success) {
 						return ctx.addIssues(parseResult.issues, [key]);
@@ -983,6 +1152,10 @@ export class KRef<
 				const fieldValue = value[key];
 
 				if (fieldValue === undefined) {
+					if (this.def.shape[key] instanceof KOptional) {
+						continue;
+					}
+
 					throw new Error(`Missing required property: ${key}`);
 				}
 
@@ -1029,11 +1202,13 @@ export class KRef<
 			for (const key in this.def.shape) {
 				if (Object.prototype.hasOwnProperty.call(this.def.shape, key)) {
 					const value = (json as {[key: string]: unknown})[key];
-					if (value === undefined) {
+					const fieldSchema = this.def.shape[key]!;
+
+					if (value === undefined && !(fieldSchema instanceof KOptional) && !(fieldSchema instanceof KDefault)) {
 						return ctx.addIssue(`Missing required property: ${key}`, [key]);
 					}
 
-					const parseResult = this.def.shape[key]!.parseSafe(value);
+					const parseResult = fieldSchema.parseSafe(value);
 
 					if (!parseResult.success) {
 						return ctx.addIssues(parseResult.issues, [key]);
@@ -1481,6 +1656,9 @@ export class KLazy<Input extends JSONValue, Output> extends BaseSchema<Input, Ou
 export const k = {
 	string: KString.create,
 	number: KNumber.create,
+	coerce: {
+		number: KCoercedNumber.create,
+	},
 	boolean: KBoolean.create,
 	array: KArray.create,
 	null: KNull.create,

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -1074,11 +1074,11 @@ export class KObject<
 
 export class KObjectFromURLSearchParams<
 	Input extends Record<keyof Output, JSONValue>,
-	Output extends Record<keyof Input, JSONValue>,
+	Output extends Record<keyof Input, unknown>,
 > extends KObject<Input, Output> {
 	public static override create = <
 		Input extends Record<keyof Output, JSONValue>,
-		Output extends Record<keyof Input, JSONValue>,
+		Output extends Record<keyof Input, unknown>,
 	>(shape: {
 		[K in keyof Input | keyof Output]: BaseSchema<Input[K], Output[K], BaseSchemaDef<Input[K]>>;
 	}) => new KObjectFromURLSearchParams({shape});


### PR DESCRIPTION
Adds schema modifiers that were missing (IMO) from `k`:

- `.optional()` — accepts `undefined`, dropped from the OpenAPI `required` list
- `.nullable()` / `.nullish()` — accept `null` / `null | undefined`
- `.default(value)` — falls back to `value` when `undefined`, surfaced as `default` in OpenAPI
- `k.coerce.number()` — parses numeric strings before the usual number checks (query params, form data)

`object`, `ref` and `objectFromURLSearchParams` honour optional & default fields when parsing/serializing. A genuinely-missing required property still errors with `Missing required property` as before. Tests added for each.

```ts
const user = k.object({
  id: k.coerce.number(),        // "1" -> 1
  name: k.string(),
  bio: k.string().optional(),
  role: k.string().default('user'),
});
```

I used them successfully before in https://github.com/pxseu/pxseu.com (as a [patch](https://raw.githubusercontent.com/pxseu/pxseu.com/refs/heads/senpai/patches/%40kaito-http%252Fcore%404.0.0-beta.33.patch)), and they came in clutch honestly.…les, make getContext and onError optional, move server options into the router to require less boilerplate, add openapi example